### PR TITLE
Update to add `sortplist.py`

### DIFF
--- a/sortplist.py
+++ b/sortplist.py
@@ -1,0 +1,13 @@
+#/usr/bin/env python3
+
+# Save as sortplist.py
+
+# Run `$ python3 sortplist.py original.plist >sorted.plist`
+
+import plistlib
+import sys
+
+with open(sys.argv[1], 'rb') as f:
+    plist = plistlib.load(f)
+xml_bytes = plistlib.dumps(plist, sort_keys=True)
+print(str(xml_bytes, 'utf-8'))


### PR DESCRIPTION
https://stackoverflow.com/a/10365250/16198018

pip install 없이 실행 가능합니다.
plistlib 는 standard libraries 에 포함돼있습니다.

https://docs.python.org/3/library/plistlib.html

https://stackoverflow.com/questions/50592074/how-to-install-plistlib-in-python3-virtualenv